### PR TITLE
fix: upgrading terraform version to 1.3.0

### DIFF
--- a/test/stages/stage0.tf
+++ b/test/stages/stage0.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0.0"
 
   required_providers {
     ibm = {

--- a/test/stages/stage0.tf
+++ b/test/stages/stage0.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     ibm = {

--- a/version.tf
+++ b/version.tf
@@ -5,7 +5,6 @@ terraform {
       version = ">= 1.9.0"
     }
   }
-  experiments = [module_variable_optional_attrs]
-  required_version = ">= 0.15"
+  required_version = ">= 1.3.0"
 }
 


### PR DESCRIPTION
### Description

  - Optional attributes are removed in order to support latest Terraform version i.e.
    `experiments = [module_variable_optional_attrs]`
  - Terraform version is updated i.e.`required_version = ">= 1.3.0"`


### Types of changes in this PR

#### No release required

- [x] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [x] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
